### PR TITLE
Revert "Bump actions/setup-java from 3.6.0 to 3.7.0"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
           java-version: 8


### PR DESCRIPTION
This reverts commit bcac97d46d2c568643f3b56a598ad66987d41a06 with PR #72.

See https://github.com/actions/setup-java/issues/422
